### PR TITLE
Handling when the query results in a null value

### DIFF
--- a/LinqCache/Containers/MemoryCacheContainer.cs
+++ b/LinqCache/Containers/MemoryCacheContainer.cs
@@ -13,6 +13,11 @@ namespace LinqCache.Containers
 		/// </summary>
 		private readonly MemoryCache _memoryCache;
 
+  		/// <summary>
+        	/// MemoryCache does not allow storing null values
+        	/// </summary>
+  		private readonly Object _nullObject = new object();
+
 		/// <summary>
 		/// Initializes a new instance of the MemoryCacheContainer.
 		/// </summary>
@@ -40,11 +45,13 @@ namespace LinqCache.Containers
 
 		public override void Set(string key, object value)
 		{
+		  	if (value == null) value = _nullObject;
 			_memoryCache.Set(key, value, null);
 		}
 
 		public override void Set(string key, object value, TimeSpan duration)
 		{
+  			if (value == null) value = _nullObject;
 			var absoluteExperiation = DateTimeOffset.Now + duration;
 			_memoryCache.Set(key, value, absoluteExperiation);
 		}
@@ -56,6 +63,8 @@ namespace LinqCache.Containers
 			var isCached = cacheItem != null;
 
 			value = isCached ? cacheItem.Value : null;
+   			if (value == _nullObject) value = null;
+      
 			return isCached;
 		}
 

--- a/LinqCache/Containers/MemoryCacheContainer.cs
+++ b/LinqCache/Containers/MemoryCacheContainer.cs
@@ -63,7 +63,7 @@ namespace LinqCache.Containers
 			var isCached = cacheItem != null;
 
 			value = isCached ? cacheItem.Value : null;
-   			if (value == _nullObject) value = null;
+   			if (Object.ReferenceEquals(value, _nullObject)) value = null;
       
 			return isCached;
 		}

--- a/LinqCache/Containers/MemoryCacheContainer.cs
+++ b/LinqCache/Containers/MemoryCacheContainer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Caching;
 
 namespace LinqCache.Containers


### PR DESCRIPTION
In some cases the query may return null, but the memorycache does not allow storing null values.
To work around, an object is created and compared every time something is read, if it is from the instance, change it to null.
